### PR TITLE
Only return current open houses in listing response

### DIFF
--- a/app/api/listing_detail/[listing_id]/route.ts
+++ b/app/api/listing_detail/[listing_id]/route.ts
@@ -27,8 +27,12 @@ export async function GET(
       { status: 404 }
     )
   }
+  const currentOpenHouses = listing.openHouses?.filter((openHouse) => {
+    return openHouse.start > new Date()
+  })
   return NextResponse.json({
     ...listing.toObject(),
+    openHouses: currentOpenHouses,
     daysOnMarket: daysOnMarket(listing.listedDate, listing.soldDate)
   })
 }

--- a/bin/generate_listing_geocode_data.ts
+++ b/bin/generate_listing_geocode_data.ts
@@ -7,6 +7,8 @@ import {
   generateRandomGeospatialDataForPoly
 } from '../lib/random_data'
 
+const VerificationMax = 10
+
 const DefaultOutputPath = path.join(
   __dirname,
   '..',
@@ -44,8 +46,13 @@ const processArgv = async () => {
     .option('number', {
       alias: 'n',
       type: 'number',
-      default: 100,
+      default: 1,
       describe: 'Number of addresses to lookup for each polygon'
+    })
+    .option('verify', {
+      type: 'boolean',
+      describe:
+        'Verify that you want to execute API requests for a large number of addresses'
     })
     .option('output-path', {
       alias: 'o',
@@ -70,11 +77,20 @@ const processArgv = async () => {
 
 const main = async () => {
   try {
-    console.warn(
-      'Be careful about running this too much. We can get charged a lot for overages for Geocode API request'
-    )
     const argv = await processArgv()
 
+    if (argv.number > VerificationMax && !argv.verify) {
+      console.log(
+        `Number argument of "${argv.number}" is too large.`,
+        `Must pass "--verify" flag in order to do API requests for batches larger than ${VerificationMax}`,
+        'In order to avoid overages.'
+      )
+      process.exit(1)
+    }
+    console.warn(
+      'Warning! Be careful about running this too much.',
+      'We can get charged a lot for overages for Geocode API requests.'
+    )
     const boundaries = JSON.parse(
       fs.readFileSync(argv.file, 'utf-8')
     ) as IBoundary[]

--- a/package.json
+++ b/package.json
@@ -9,12 +9,11 @@
     "lint": "next lint --dir .",
     "check-types": "tsc --noEmit",
     "test": "jest",
-    "generate_listing_geocode_data": "bun run ./bin/generate_listing_geocode_data",
     "generate_listing_data": "bun run ./bin/generate_listing_data",
     "seed_listing_data": "bun run ./bin/seed_listing_data",
     "seed_boundary_data": "bun run ./bin/seed_boundary_data",
     "seed_dev_data": "bun run ./bin/seed_boundary_data && bun run ./bin/seed_listing_data",
-    "generate_and_seed_listing_data": "bun run ./bin/generate_listing_geocode_data && bun run ./bin/generate_listing_data && bun run ./bin/seed_listing_data",
+    "generate_and_seed_listing_data": "bun run ./bin/generate_listing_data && bun run ./bin/seed_listing_data",
     "prisma:generate:local": "dotenv -e .env.local prisma generate",
     "prisma:validate:local": "dotenv -e .env.local prisma validate"
   },


### PR DESCRIPTION
We are showing open houses that are in the past. Just show current and future open houses. Also, added safety checks for geocode lookup.