### PR TITLE
#127 - Boundary outside viewport bug

### DIFF
--- a/app/api/listing/search/boundary/[id]/route.ts
+++ b/app/api/listing/search/boundary/[id]/route.ts
@@ -6,25 +6,32 @@ import Boundary from '../../../../../../models/BoundaryModel'
 import { getPaginationParams } from '../../../../../../lib'
 import { getBoundaryGeometryWithBounds } from '../../../../../../lib/listing_search_helpers'
 import listingSearchBoundaryView from '../../../../../../views/listingSearchBoundaryView'
-import { boundsSearchQuerySchema } from '../../../../../../zod_schemas/boundsSearchRequestSchema'
+import {
+  type BoundarySearchParams,
+  boundarySearchRequestSchema
+} from '../../../../../../zod_schemas/boundarySearchRequestSchema'
 
-export type BoundaryParams = {
-  params: {
-    id: string
-  }
+export type BoundaryRequstParams = {
+  params: BoundarySearchParams
 }
 
-export async function GET(request: NextRequest, { params }: BoundaryParams) {
+export async function GET(
+  request: NextRequest,
+  { params }: BoundaryRequstParams
+) {
   await mongooseConnect()
 
   const searchParamsObject = Object.fromEntries(
     request.nextUrl.searchParams.entries()
   )
-  const result = boundsSearchQuerySchema.safeParse(searchParamsObject)
+  const result = boundarySearchRequestSchema.safeParse({
+    query: searchParamsObject,
+    params
+  })
   if (!result.success) {
     return NextResponse.json(result.error, { status: 400 })
   }
-  const searchParams = result.data
+  const searchParams = result.data.query
 
   const boundary = await Boundary.findById(params.id)
   if (!boundary) {

--- a/app/api/listing/search/boundary/[id]/route.ts
+++ b/app/api/listing/search/boundary/[id]/route.ts
@@ -41,8 +41,16 @@ export async function GET(
     )
   }
   const pagination = getPaginationParams(searchParams)
+  const bounds = getBoundaryGeometryWithBounds(boundary, searchParams)
+  // Map viewport bounds were included but the boundary was moved outside the
+  // viewport, so there's nothing to search.
+  if (bounds === null) {
+    return NextResponse.json(
+      listingSearchBoundaryView(boundary, null, pagination)
+    )
+  }
   const results = await Listing.findWithinBounds(
-    getBoundaryGeometryWithBounds(boundary, searchParams),
+    bounds,
     searchParams,
     pagination
   )

--- a/components/listings/NoResults/NoResults.tsx
+++ b/components/listings/NoResults/NoResults.tsx
@@ -1,27 +1,13 @@
-import type { NextPage } from 'next'
 import styles from './NoResults.module.css'
-import ContainedButton from '../../design_system/ContainedButton/ContainedButton'
 
-export interface NoResultsProps {
-  onClearFiltersClick: () => void
-}
-
-const NoResults: NextPage<NoResultsProps> = ({ onClearFiltersClick }) => {
+const NoResults: React.FC = () => {
   return (
     <div className={styles.noResults}>
       <div className={styles.emoji}>🤷‍♂️</div>
       <p className={styles.message}>
-        Hmm, we can&apos;t find anything for this search.
-        Try removing some filters and see if that helps.
+        Hmm, we can&apos;t find anything for this search. Try removing some
+        filters or adjusting the map and see if that helps.
       </p>
-      <p className={styles.message}>
-        Or, just nuke them all! 💥
-      </p>
-      <ContainedButton
-        onClick={onClearFiltersClick}
-      >
-        Clear All Filters
-      </ContainedButton>
     </div>
   )
 }

--- a/containers/SearchResults/SearchResults.tsx
+++ b/containers/SearchResults/SearchResults.tsx
@@ -62,11 +62,6 @@ const SearchResults: NextPage = () => {
     dispatch(setHighlightedMarker(null))
   }
 
-  const handleClearAll = () => {
-    dispatch(clearFilters())
-    dispatch(searchWithUpdatedFilters())
-  }
-
   const resultsClassName =
     mobileViewType === 'list'
       ? styles.searchResultsMobileListView
@@ -93,7 +88,7 @@ const SearchResults: NextPage = () => {
       {listings.length === 0 &&
         initialSearchComplete &&
         !listingSearchRunning && (
-          <NoResults onClearFiltersClick={handleClearAll} />
+          <NoResults />
         )}
       {listings.length > 0 && (
         <ListingResultsPagination

--- a/lib/listing_search_helpers.ts
+++ b/lib/listing_search_helpers.ts
@@ -33,7 +33,8 @@ export const daysOnMarket = (
 }
 
 /**
- * Converts a set of north/east/south/west coordinates into a rectangular polygon
+ * Converts a set of north/east/south/west coordinates into a rectangular
+ * polygon
  */
 export const boundsParamsToGeoJSONPolygon = (bounds: BoundsParams): Polygon => {
   const { bounds_north, bounds_east, bounds_south, bounds_west } = bounds
@@ -42,8 +43,9 @@ export const boundsParamsToGeoJSONPolygon = (bounds: BoundsParams): Polygon => {
 }
 
 /**
- * Remove any parts of a boundary that are outside of a set of bounds. These bounds typically represent the viewport of
- * a map. The purpose of doing this is adjust a geospatial boundary in order to avoid returning listings that are
+ * Remove any parts of a boundary that are outside of a set of bounds. These
+ * bounds typically represent the viewport of a map. The purpose of doing this
+ * is adjust a geospatial boundary in order to avoid returning listings that are
  * outside the map viewport.
  */
 export const removePartsOfBoundaryOutsideOfBounds = (
@@ -55,8 +57,9 @@ export const removePartsOfBoundaryOutsideOfBounds = (
 }
 
 /**
- * If bounds params are present, modify the boundary so that any parts that are outside of the bounds will be
- * removed. This way the search will only return results that are within both the boundary + the bounds.
+ * If bounds params are present, modify the boundary so that any parts that are
+ * outside of the bounds will be removed. This way the search will only return
+ * results that are within both the boundary + the bounds.
  */
 export const getBoundaryGeometryWithBounds = (
   boundary: IBoundary,
@@ -101,8 +104,8 @@ export const getResponseForPlaceId = async (
 ) => {
   const { place_id, address_types } = queryParams
   if (!place_id || !address_types) return
-  // If it's an address we will need to geocode so we can't just use place_id. Logic in the controller handles that for
-  // the sake of effeciency
+  // If it's an address we will need to geocode so we can't just use place_id.
+  // Logic in the controller handles that for the sake of effeciency
   if (isListingAddressType(getAddressTypesFromParams(address_types))) return
 
   const pagination = getPaginationParams(queryParams)

--- a/lib/listing_search_helpers.ts
+++ b/lib/listing_search_helpers.ts
@@ -45,15 +45,17 @@ export const boundsParamsToGeoJSONPolygon = (bounds: BoundsParams): Polygon => {
 /**
  * Remove any parts of a boundary that are outside of a set of bounds. These
  * bounds typically represent the viewport of a map. The purpose of doing this
- * is adjust a geospatial boundary in order to avoid returning listings that are
- * outside the map viewport.
+ * is to adjust a geospatial boundary in order to avoid returning listings that
+ * are outside the map viewport. If intersect returns null that means the
+ * boundary is outside the viewport, which case we can return null as a signal
+ * to avoid trying to search.
  */
 export const removePartsOfBoundaryOutsideOfBounds = (
   bounds: BoundsParams,
   boundary: Polygon | MultiPolygon
 ) => {
   const boundsPolygon = boundsParamsToGeoJSONPolygon(bounds)
-  return intersect(boundsPolygon, boundary)?.geometry
+  return intersect(boundsPolygon, boundary)?.geometry || null
 }
 
 /**
@@ -64,14 +66,11 @@ export const removePartsOfBoundaryOutsideOfBounds = (
 export const getBoundaryGeometryWithBounds = (
   boundary: IBoundary,
   queryParams: BoundarySearchQueryParams
-): Polygon | MultiPolygon => {
+) => {
   const { bounds_north, bounds_east, bounds_south, bounds_west } = queryParams
   if (bounds_north && bounds_east && bounds_south && bounds_west) {
     const bounds = { bounds_north, bounds_east, bounds_south, bounds_west }
-    return (
-      removePartsOfBoundaryOutsideOfBounds(bounds, boundary.geometry) ||
-      boundary.geometry
-    )
+    return removePartsOfBoundaryOutsideOfBounds(bounds, boundary.geometry)
   } else {
     return boundary.geometry
   }

--- a/views/listingSearchBoundaryView.ts
+++ b/views/listingSearchBoundaryView.ts
@@ -7,7 +7,7 @@ import listingSearchView from './listingSearchView'
 
 const listingSearchBoundaryView = (
   boundary: IBoundary,
-  results: ListingSearchAggregateResult<ListingResultWithSelectedFields>,
+  results: ListingSearchAggregateResult<ListingResultWithSelectedFields> | null,
   pagination: PaginationParams
 ): BoundarySearchResponse => {
   return {

--- a/views/listingSearchView.ts
+++ b/views/listingSearchView.ts
@@ -6,18 +6,19 @@ import type {
 } from '../types/listing_search_response_types'
 
 const listingSearchView = <T = ListingResultWithSelectedFields>(
-  results: ListingSearchAggregateResult<T>,
+  results: ListingSearchAggregateResult<T> | null,
   pagination: PaginationParams
 ): ListingSearchResponse<T> => {
-  const { listings, metadata } = results[0]
-  const numberAvailable = metadata[0]?.numberAvailable || 0
+  const result = results?.[0]
+  const listings = result?.listings || []
+  const numberAvailable = result?.metadata?.[0]?.numberAvailable || 0
   return {
-    listings: listings,
+    listings,
     pagination: {
       page: pagination.page_index,
       pageSize: pagination.page_size,
       numberReturned: listings.length,
-      numberAvailable: numberAvailable,
+      numberAvailable,
       numberOfPages: Math.ceil(numberAvailable / pagination.page_size)
     }
   }

--- a/zod_schemas/boundarySearchRequestSchema.ts
+++ b/zod_schemas/boundarySearchRequestSchema.ts
@@ -24,13 +24,15 @@ export const boundarySearchQuerySchema = boundsParamsSchema
     }
   )
 
-export const boundarySearchRequestSchema = z.object({
-  query: boundarySearchQuerySchema,
-  params: z.object({
-    id: z.string().regex(/^[0-9a-f]{24}$/, 'ID should be a MongoDB ObjectId')
-  })
+export const boundarySearchParamsSchema = z.object({
+  id: z.string().regex(/^[0-9a-f]{24}$/, 'ID should be a MongoDB ObjectId')
 })
 
-export type BoundarySearchQueryParams = z.infer<typeof boundarySearchQuerySchema>
+export const boundarySearchRequestSchema = z.object({
+  query: boundarySearchQuerySchema,
+  params: boundarySearchParamsSchema
+})
 
-export type BoundarySearchRequest = z.infer<typeof boundarySearchRequestSchema>
+export type BoundarySearchParams = z.infer<typeof boundarySearchParamsSchema>
+
+export type BoundarySearchQueryParams = z.infer<typeof boundarySearchQuerySchema>


### PR DESCRIPTION
Moving bounds completely outside viewport returns all listings within bounds.

This was happening because we when the intersect function finds no intersection between the viewport bounds and the boundary it returns null. We were just returning the boundary if it returned null, so it searched as if the boundary were visible in the viewport. We will now return that null value from intersect() and return early if it's null.